### PR TITLE
Improve README and fix autoload path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ m4/lt~obsolete.m4
 # can automatically generate from config.status script
 # (which is called by configure script))
 Makefile
+/techno-auf-den-augen-admin/.env
+/techno-auf-den-augen-admin/vendor/

--- a/ADMIN.md
+++ b/ADMIN.md
@@ -1,0 +1,21 @@
+# ADMIN Anleitung
+
+Dieses Dokument beschreibt die grundlegende Verwendung des Projekts **TadA**.
+
+## Einrichtung
+1. Wechsle in den Ordner `techno-auf-den-augen-admin/`.
+2. Führe `composer install` aus, um PHP-Abhängigkeiten zu laden.
+3. Lege eine Datei `.env` mit folgenden Variablen an:
+   - `FB_APP_ID`
+   - `FB_APP_SECRET`
+   - `FB_ACCESS_TOKEN`
+4. Stelle sicher, dass die Datei `.env` nicht ins Repository eingecheckt wird.
+
+## Nutzung
+- Die PHP-Skripte im Ordner `backend/` kapseln die Facebook Graph API.
+- Über das Dashboard in `frontend/` können Beiträge verwaltet und Statistiken
+eingesehen werden.
+
+## Sicherheit
+- Zugriffstoken sollten regelmäßig erneuert und sicher verwahrt werden.
+- Vermeide es, sensible Daten im Quellcode abzulegen.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # TEST-Seite
+
+Dieses Repository enthält das Projekt **TadA** ("Techno auf den Augen Admin").
+Die Anwendung erleichtert die Verwaltung der gleichnamigen Facebook-Seite über die Facebook Graph API.
+Das Admin-Panel befindet sich im Unterordner `techno-auf-den-augen-admin/` und
+ist für die Domain <https://tada.die-paten.biz> vorgesehen.
+
+## Schnellstart
+
+```bash
+cd techno-auf-den-augen-admin
+composer install
+php -S localhost:8000 -t frontend
+```
+
+Rufe anschließend <http://localhost:8000> im Browser auf, um das Dashboard zu testen.

--- a/techno-auf-den-augen-admin/README.md
+++ b/techno-auf-den-augen-admin/README.md
@@ -1,0 +1,28 @@
+# Techno auf den Augen Admin
+
+Dieses Projekt bietet ein einfaches Dashboard, um die Facebook-Seite **"Techno auf den Augen"** zu verwalten. Die Anwendung nutzt die Facebook Graph API, um Posts, Kommentare und Statistiken abzurufen.
+
+## Struktur
+- **backend/** – PHP‑Skripte zur Kommunikation mit der Graph API
+- **frontend/** – HTML, CSS und JavaScript für das Dashboard
+- **assets/** – Statische Dateien wie Bilder oder Icons
+- **.env** – Enthält Zugangsdaten wie API‑Key und Token (nicht ins Repository einchecken)
+
+## Einrichtung
+1. `composer install` ausführen, um Abhängigkeiten zu laden.
+2. In der Datei `.env` die Facebook‑App‑ID und den Zugriffstoken hinterlegen.
+3. Den Webserver so konfigurieren, dass die Dateien aus `frontend/` erreichbar sind.
+   Das Verzeichnis `backend/` sollte PHP ausführen können.
+
+## Nutzung
+Nach der Einrichtung kann das Dashboard direkt im Browser aufgerufen werden.
+Wichtige Aktionen:
+- Beiträge erstellen oder zeitgesteuert planen
+- Letzte Posts abrufen und anzeigen
+- Kommentare lesen und beantworten
+- Reaktionen und Insights einsehen
+
+Alle Funktionen greifen über `backend/api.php` auf die Facebook Graph API zu.
+
+## Hinweis
+Dieses Projekt stellt ein minimal lauffähiges Admin-Panel dar und kann beliebig erweitert werden.

--- a/techno-auf-den-augen-admin/backend/analytics.php
+++ b/techno-auf-den-augen-admin/backend/analytics.php
@@ -1,0 +1,8 @@
+<?php
+require_once __DIR__ . '/facebook-api.php';
+
+function getInsights(string $pageId, array $metrics): array {
+    global $fb;
+    $metricStr = implode(',', $metrics);
+    return $fb->get("$pageId/insights", ['metric' => $metricStr]);
+}

--- a/techno-auf-den-augen-admin/backend/api.php
+++ b/techno-auf-den-augen-admin/backend/api.php
@@ -1,0 +1,50 @@
+<?php
+require_once __DIR__ . '/posts.php';
+require_once __DIR__ . '/comments.php';
+require_once __DIR__ . '/analytics.php';
+require_once __DIR__ . '/engagement.php';
+
+header('Content-Type: application/json');
+$method = $_SERVER['REQUEST_METHOD'];
+$action = $_GET['action'] ?? '';
+
+try {
+    switch ($action) {
+        case 'createPost':
+            echo json_encode(createPost($_POST['pageId'], $_POST['message']));
+            break;
+        case 'schedulePost':
+            $time = intval($_POST['timestamp']);
+            echo json_encode(schedulePost($_POST['pageId'], $_POST['message'], $time));
+            break;
+        case 'deletePost':
+            echo json_encode(deletePost($_POST['postId']));
+            break;
+        case 'getPosts':
+            $limit = isset($_GET['limit']) ? intval($_GET['limit']) : 10;
+            echo json_encode(getPosts($_GET['pageId'], $limit));
+            break;
+        case 'getComments':
+            echo json_encode(getComments($_GET['postId']));
+            break;
+        case 'replyComment':
+            echo json_encode(replyComment($_POST['commentId'], $_POST['message']));
+            break;
+        case 'getInsights':
+            $metrics = isset($_GET['metrics']) ? explode(',', $_GET['metrics']) : [];
+            echo json_encode(getInsights($_GET['pageId'], $metrics));
+            break;
+        case 'getReactions':
+            echo json_encode(getReactions($_GET['postId']));
+            break;
+        case 'getShares':
+            echo json_encode(getShares($_GET['postId']));
+            break;
+        default:
+            http_response_code(400);
+            echo json_encode(['error' => 'unknown action']);
+    }
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}

--- a/techno-auf-den-augen-admin/backend/comments.php
+++ b/techno-auf-den-augen-admin/backend/comments.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/facebook-api.php';
+
+function getComments(string $postId): array {
+    global $fb;
+    return $fb->get("$postId/comments");
+}
+
+function replyComment(string $commentId, string $message): array {
+    global $fb;
+    return $fb->post("$commentId/replies", ['message' => $message]);
+}

--- a/techno-auf-den-augen-admin/backend/config.php
+++ b/techno-auf-den-augen-admin/backend/config.php
@@ -1,0 +1,7 @@
+<?php
+// Datenbank- und API-Einstellungen
+return [
+    'fb_app_id' => getenv('FB_APP_ID'),
+    'fb_app_secret' => getenv('FB_APP_SECRET'),
+    'fb_access_token' => getenv('FB_ACCESS_TOKEN'),
+];

--- a/techno-auf-den-augen-admin/backend/engagement.php
+++ b/techno-auf-den-augen-admin/backend/engagement.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/facebook-api.php';
+
+function getReactions(string $postId): array {
+    global $fb;
+    return $fb->get("$postId/reactions", ['summary' => 'true']);
+}
+
+function getShares(string $postId): array {
+    global $fb;
+    return $fb->get("$postId", ['fields' => 'shares']);
+}

--- a/techno-auf-den-augen-admin/backend/facebook-api.php
+++ b/techno-auf-den-augen-admin/backend/facebook-api.php
@@ -1,0 +1,34 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+$config = require __DIR__ . '/config.php';
+
+use GuzzleHttp\Client;
+
+class FacebookAPI {
+    private Client $client;
+    private string $token;
+
+    public function __construct(string $token) {
+        $this->client = new Client(['base_uri' => 'https://graph.facebook.com/']);
+        $this->token = $token;
+    }
+
+    public function get(string $endpoint, array $params = []): array {
+        $params['access_token'] = $this->token;
+        $response = $this->client->get($endpoint, ['query' => $params]);
+        return json_decode($response->getBody()->getContents(), true);
+    }
+
+    public function post(string $endpoint, array $data = []): array {
+        $data['access_token'] = $this->token;
+        $response = $this->client->post($endpoint, ['form_params' => $data]);
+        return json_decode($response->getBody()->getContents(), true);
+    }
+
+    public function delete(string $endpoint): array {
+        $response = $this->client->delete($endpoint, ['query' => ['access_token' => $this->token]]);
+        return json_decode($response->getBody()->getContents(), true);
+    }
+}
+
+$fb = new FacebookAPI($config['fb_access_token']);

--- a/techno-auf-den-augen-admin/backend/posts.php
+++ b/techno-auf-den-augen-admin/backend/posts.php
@@ -1,0 +1,26 @@
+<?php
+require_once __DIR__ . '/facebook-api.php';
+
+function createPost(string $pageId, string $message): array {
+    global $fb;
+    return $fb->post("$pageId/feed", ['message' => $message]);
+}
+
+function schedulePost(string $pageId, string $message, int $timestamp): array {
+    global $fb;
+    return $fb->post("$pageId/feed", [
+        'message' => $message,
+        'published' => 'false',
+        'scheduled_publish_time' => $timestamp
+    ]);
+}
+
+function getPosts(string $pageId, int $limit = 10): array {
+    global $fb;
+    return $fb->get("$pageId/posts", ['limit' => $limit]);
+}
+
+function deletePost(string $postId): array {
+    global $fb;
+    return $fb->delete($postId);
+}

--- a/techno-auf-den-augen-admin/composer.json
+++ b/techno-auf-den-augen-admin/composer.json
@@ -1,0 +1,7 @@
+{
+    "name": "die-paten/techno-auf-den-augen-admin",
+    "description": "Admin panel for Facebook page management via Graph API",
+    "require": {
+        "guzzlehttp/guzzle": "^7.0"
+    }
+}

--- a/techno-auf-den-augen-admin/composer.lock
+++ b/techno-auf-den-augen-admin/composer.lock
@@ -1,0 +1,615 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "918b7da5a374e95181f10aa8ff48e708",
+    "packages": [
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.9.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
+                "reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^1.5.3 || ^2.0.3",
+                "guzzlehttp/psr7": "^2.7.0",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "ext-curl": "*",
+                "guzzle/client-integration-tests": "3.0.2",
+                "php-http/message-factory": "^1.1",
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Jeremy Lindblom",
+                    "email": "jeremeamia@gmail.com",
+                    "homepage": "https://github.com/jeremeamia"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/7.9.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-03-27T13:37:11+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "7c69f28996b0a6920945dd20b3857e499d9ca96c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/7c69f28996b0a6920945dd20b3857e499d9ca96c",
+                "reference": "7c69f28996b0a6920945dd20b3857e499d9ca96c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/2.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/promises",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-03-27T13:27:01+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "2.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/c2270caaabe631b3b44c85f99e5a04bbb8060d16",
+                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
+                "ralouphie/getallheaders": "^3.0"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "http-interop/http-factory-tests": "0.9.0",
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/2.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-03-27T12:30:47+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
+}

--- a/techno-auf-den-augen-admin/frontend/index.html
+++ b/techno-auf-den-augen-admin/frontend/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8" />
+    <title>Techno auf den Augen – Admin</title>
+    <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+    <h1>Techno auf den Augen – Dashboard</h1>
+    <section>
+        <h2>Neuen Post erstellen</h2>
+        <form id="postForm">
+            <input type="text" id="pageId" placeholder="Page ID" required />
+            <textarea id="message" placeholder="Nachricht" required></textarea>
+            <button type="submit">Posten</button>
+        </form>
+    </section>
+
+    <section>
+        <h2>Geplanten Post erstellen</h2>
+        <form id="scheduleForm">
+            <input type="text" id="sPageId" placeholder="Page ID" required />
+            <textarea id="sMessage" placeholder="Nachricht" required></textarea>
+            <input type="datetime-local" id="publishTime" required />
+            <button type="submit">Planen</button>
+        </form>
+    </section>
+
+    <section>
+        <h2>Letzte Posts</h2>
+        <button id="refreshPosts">Aktualisieren</button>
+        <ul id="posts"></ul>
+    </section>
+    <script src="scripts.js"></script>
+</body>
+</html>

--- a/techno-auf-den-augen-admin/frontend/scripts.js
+++ b/techno-auf-den-augen-admin/frontend/scripts.js
@@ -1,0 +1,40 @@
+console.log('Dashboard loaded');
+
+async function api(action, data) {
+    const formData = new URLSearchParams(data);
+    const response = await fetch(`../backend/api.php?action=${action}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: formData.toString()
+    });
+    return response.json();
+}
+
+document.getElementById('postForm').addEventListener('submit', async e => {
+    e.preventDefault();
+    const pageId = document.getElementById('pageId').value;
+    const message = document.getElementById('message').value;
+    const result = await api('createPost', { pageId, message });
+    alert(JSON.stringify(result));
+});
+
+document.getElementById('scheduleForm').addEventListener('submit', async e => {
+    e.preventDefault();
+    const pageId = document.getElementById('sPageId').value;
+    const message = document.getElementById('sMessage').value;
+    const time = new Date(document.getElementById('publishTime').value).getTime() / 1000;
+    const result = await api('schedulePost', { pageId, message, timestamp: time });
+    alert(JSON.stringify(result));
+});
+
+document.getElementById('refreshPosts').addEventListener('click', async () => {
+    const pageId = document.getElementById('pageId').value;
+    const posts = await fetch(`../backend/api.php?action=getPosts&pageId=${pageId}`).then(r => r.json());
+    const list = document.getElementById('posts');
+    list.innerHTML = '';
+    posts.data?.forEach(p => {
+        const li = document.createElement('li');
+        li.textContent = p.message || p.id;
+        list.appendChild(li);
+    });
+});

--- a/techno-auf-den-augen-admin/frontend/styles.css
+++ b/techno-auf-den-augen-admin/frontend/styles.css
@@ -1,0 +1,18 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 2rem;
+}
+
+form {
+    margin-bottom: 1rem;
+}
+
+textarea {
+    display: block;
+    width: 100%;
+    height: 5rem;
+}
+
+input, button {
+    margin-top: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- document quickstart instructions in the main README
- reference target domain
- correct vendor autoload path in backend script

## Testing
- `composer validate --no-check-all`
- `find backend -name '*.php' -print -exec php -l {} \;`

------
https://chatgpt.com/codex/tasks/task_e_6849d465b89c832585c35db452516afd